### PR TITLE
Fix: Correct user ID check in GetBalanceByUserId function

### DIFF
--- a/internal/service/finance.go
+++ b/internal/service/finance.go
@@ -97,7 +97,7 @@ func (financeService *FinanceService) GetBalanceByUserId(userID int) float64 {
 
 	var balance float64
 	for _, transaction := range financeService.Transaction {
-		if transaction.ID == userID {
+		if transaction.UserID == userID {
 			if transaction.Type == "income" {
 				balance += transaction.Amount
 			} else if transaction.Type == "expense" {


### PR DESCRIPTION
- Replace transaction.ID with transaction.UserID in the balance calculation loop
- Ensure balance is calculated only for the specified user's transactions